### PR TITLE
Send "is_jenkins_job" as part of measurement.

### DIFF
--- a/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/AbstractBuildTimeTrackerReporter.groovy
+++ b/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/AbstractBuildTimeTrackerReporter.groovy
@@ -23,7 +23,7 @@ abstract class AbstractBuildTimeTrackerReporter {
     }
 
     boolean getOption(String name, boolean defaultVal) {
-        options[name] == null ? defaultVal : options[name]
+        options[name] == null ? defaultVal : options[name].toBoolean()
     }
 
     void onBuildResult(BuildResult result) {}

--- a/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/NetworkReporter.groovy
+++ b/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/NetworkReporter.groovy
@@ -56,7 +56,8 @@ class NetworkReporter extends AbstractBuildTimeTrackerReporter {
                         date: trueTimeProvider.getCurrentDate(),
                         cpu: sysInfo.getCPUIdentifier(),
                         memory: sysInfo.getMaxMemory(),
-                        os: sysInfo.getOSIdentifier()
+                        os: sysInfo.getOSIdentifier(),
+                        is_jenkins_job: isJenkinsJob
                 ]
             }
 


### PR DESCRIPTION
PR fixes two issues:
* Send "is_jenkins_job" as part of "measurement", because this is where backend expect it to be. This is a temporary quick fix until backend is changed.
* Options have type Map<String, String>, that's why we need to convert value to boolean. Otherwise getOption("is_jenkins_", false) returns true for "is_jenkins_job : false".